### PR TITLE
Fix/preferences

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,9 @@ const DiscordRPC = require('discord-rpc');
 const fs = require('fs');
 const ElectronPrompt = require('electron-prompt');
 const ChromeErrors = require('chrome-network-errors');
-const ElectronPreferences = require(__dirname + '/electron-preferences');
+const ElectronPreferences = require('./electron-preferences/index');
 const path = require('path');
-const EBU = require(__dirname + '/electron-basic-updater');
+const EBU = require('./electron-basic-updater/index');
 const ElectronContext = require('electron-context-menu');
 const requests = require('axios');
 


### PR DESCRIPTION
`Require`s that refer to a `git submodule` now give relative paths to the `index.js` file. Makes presence of `build` file obsolete in the submodule so recommended to accept [this](https://github.com/leon332157/electron-preferences/pull/1) PR also.