### PR TITLE
Fix/preferences

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,12 @@
 /* Require Packages */
 const {app, BrowserWindow, Menu, dialog, shell} = require('electron');
+const path = require('path');
 const DiscordRPC = require('discord-rpc');
 const fs = require('fs');
 const ElectronPrompt = require('electron-prompt');
 const ChromeErrors = require('chrome-network-errors');
-const ElectronPreferences = require('./electron-preferences/index');
-const path = require('path');
-const EBU = require('./electron-basic-updater/index');
+const ElectronPreferences = require(path.resolve('.', 'electron-preferences', 'index'));
+const EBU = require(path.resolve('.', 'electron-basic-updater', 'index'));
 const ElectronContext = require('electron-context-menu');
 const requests = require('axios');
 


### PR DESCRIPTION
Writes relative urls to git submodules using. This fixes `electron-preferences` issue as long as the HEAD in `electron-preferences` submodule is at this commit hash: f9a1f8fdca507506e56984f0c879dfe404b6632d.